### PR TITLE
Fix Tech Stack plugins crash on non-string setValueAs input

### DIFF
--- a/src/components/form/step-tech.tsx
+++ b/src/components/form/step-tech.tsx
@@ -112,7 +112,9 @@ export function StepTech({ register }: Props) {
           {...register("tech.plugins", {
             setValueAs: (v: unknown) => {
               if (Array.isArray(v)) {
-                return v.filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+                return v
+                  .filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+                  .map((item) => item.trim())
               }
 
               if (typeof v !== "string") {

--- a/src/components/form/step-tech.tsx
+++ b/src/components/form/step-tech.tsx
@@ -110,11 +110,20 @@ export function StepTech({ register }: Props) {
         <textarea
           id="plugins"
           {...register("tech.plugins", {
-            setValueAs: (v: string) =>
-              v
+            setValueAs: (v: unknown) => {
+              if (Array.isArray(v)) {
+                return v.filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+              }
+
+              if (typeof v !== "string") {
+                return []
+              }
+
+              return v
                 .split("\n")
                 .map((line) => line.trim())
-                .filter(Boolean),
+                .filter(Boolean)
+            },
           })}
           className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm font-mono"
           rows={4}


### PR DESCRIPTION
## Summary
- guard the `tech.plugins` textarea transform against non-string values
- safely handle arrays, empty values, and unexpected inputs instead of calling `.split()` blindly
- keep newline splitting behavior for normal textarea input

## Verification
- `pnpm lint`
- `pnpm build`
- manual QA on local dev server: `/new` -> `Tech Stack` loads without crashing and accepts plugin input

Fixes #16
