### PR TITLE
feat(schema): expand config for dashboards, internal tools, and app-shape hints

### DIFF
--- a/src/app/new/page.tsx
+++ b/src/app/new/page.tsx
@@ -9,12 +9,14 @@ import { StepBrand } from "@/components/form/step-brand"
 import { StepTech } from "@/components/form/step-tech"
 // StepPages is imported when needed for Issue #4
 import { StepPages } from "@/components/form/step-pages"
+import { StepApp } from "@/components/form/step-app"
 import { StepReview } from "@/components/form/step-review"
 
 const steps = [
   { id: "project" as const, label: "Project Info", icon: "📋" },
   { id: "brand" as const, label: "Brand", icon: "🎨" },
   { id: "pages" as const, label: "Pages", icon: "📄" },
+  { id: "app" as const, label: "App Shape", icon: "🧩" },
   { id: "tech" as const, label: "Tech Stack", icon: "⚙️" },
   { id: "review" as const, label: "Review & Export", icon: "🚀" },
 ]
@@ -82,6 +84,9 @@ export default function NewPage() {
         )}
         {currentStep === "pages" && (
           <StepPages form={form} errors={form.formState.errors} />
+        )}
+        {currentStep === "app" && (
+          <StepApp form={form} errors={form.formState.errors} />
         )}
         {currentStep === "tech" && (
           <StepTech register={form.register} errors={form.formState.errors} />

--- a/src/components/form/step-app.tsx
+++ b/src/components/form/step-app.tsx
@@ -1,0 +1,268 @@
+"use client"
+
+import React from "react"
+import { type UseFormReturn, type FieldErrors } from "react-hook-form"
+import type { ProjectConfig } from "@/lib/config/schema"
+import { cn } from "@/lib/utils/cn"
+
+interface Props {
+  form: UseFormReturn<ProjectConfig>
+  errors: FieldErrors<ProjectConfig>
+}
+
+const CAPABILITY_OPTIONS = [
+  "auth", "search", "filters", "drag-and-drop", "notifications",
+  "automation", "integrations", "realtime", "offline", "file-upload",
+  "comments", "permissions", "audit-log", "billing", "i18n",
+]
+
+type ListKey = "capabilities" | "dataModels" | "integrations"
+
+export function StepApp({ form }: Props) {
+  const app = form.watch("app") || { capabilities: [], dataModels: [], integrations: [] }
+  const workflow = form.watch("agents.workflow") || { builder: "", updater: "", escalation: "" }
+
+  const [openInputKey, setOpenInputKey] = React.useState<ListKey | null>(null)
+  const [customValue, setCustomValue] = React.useState("")
+  const [modelDraft, setModelDraft] = React.useState("")
+  const [integrationDraft, setIntegrationDraft] = React.useState("")
+
+  function setList(key: ListKey, values: string[]) {
+    form.setValue(`app.${key}` as const, values, { shouldDirty: true })
+  }
+
+  function toggleCapability(name: string) {
+    const current = app.capabilities || []
+    const next = current.includes(name)
+      ? current.filter((c) => c !== name)
+      : [...current, name]
+    setList("capabilities", next)
+  }
+
+  function addCustomCapability() {
+    const name = customValue.trim()
+    if (!name) return
+    const current = app.capabilities || []
+    if (current.includes(name)) return
+    setList("capabilities", [...current, name])
+    setCustomValue("")
+    setOpenInputKey(null)
+  }
+
+  function addListItem(key: ListKey, value: string, clear: () => void) {
+    const name = value.trim()
+    if (!name) return
+    const current = app[key] || []
+    if (current.includes(name)) return
+    setList(key, [...current, name])
+    clear()
+  }
+
+  function removeListItem(key: ListKey, item: string) {
+    const current = app[key] || []
+    setList(key, current.filter((v) => v !== item))
+  }
+
+  function updateWorkflow(field: "builder" | "updater" | "escalation", value: string) {
+    form.setValue(`agents.workflow.${field}` as const, value, { shouldDirty: true })
+  }
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="text-3xl font-bold tracking-tight text-foreground">App Shape</h2>
+        <p className="mt-2 text-muted">
+          Declare app capabilities, data models, integrations, and agent workflow hints.
+        </p>
+      </div>
+
+      {/* Capabilities */}
+      <div>
+        <p className="text-sm font-medium mb-2">Capabilities</p>
+        <div className="flex flex-wrap gap-2">
+          {CAPABILITY_OPTIONS.map((c) => (
+            <button
+              key={c}
+              type="button"
+              onClick={() => toggleCapability(c)}
+              className={cn(
+                "rounded-full px-3 py-1 text-xs transition-colors",
+                (app.capabilities || []).includes(c)
+                  ? "bg-primary text-primary-foreground"
+                  : "border border-border bg-background hover:bg-accent/50"
+              )}
+            >
+              {c}
+            </button>
+          ))}
+          {(app.capabilities || [])
+            .filter((c) => !CAPABILITY_OPTIONS.includes(c))
+            .map((c) => (
+              <button
+                key={c}
+                type="button"
+                onClick={() => toggleCapability(c)}
+                className="rounded-full px-3 py-1 text-xs transition-colors bg-primary text-primary-foreground"
+              >
+                {c}
+              </button>
+            ))}
+          {openInputKey === "capabilities" ? (
+            <div className="flex gap-1">
+              <input
+                autoFocus
+                type="text"
+                value={customValue}
+                onChange={(e) => setCustomValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") { e.preventDefault(); addCustomCapability() }
+                  if (e.key === "Escape") { setOpenInputKey(null); setCustomValue("") }
+                }}
+                placeholder="capability"
+                className="rounded-md border border-border bg-background px-2 py-1 text-xs"
+              />
+              <button
+                type="button"
+                onClick={addCustomCapability}
+                className="rounded-md bg-primary px-2 py-1 text-xs text-white"
+              >Add</button>
+              <button
+                type="button"
+                onClick={() => { setOpenInputKey(null); setCustomValue("") }}
+                className="rounded-md border px-2 py-1 text-xs"
+              >✕</button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => { setOpenInputKey("capabilities"); setCustomValue("") }}
+              className="rounded-full border border-dashed border-border px-3 py-1 text-xs text-muted hover:border-primary hover:text-primary"
+            >
+              + custom
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Data Models */}
+      <div>
+        <p className="text-sm font-medium mb-2">Data Models</p>
+        <p className="text-xs text-muted mb-2">Hints for scaffold: e.g. tasks, projects, users, statuses.</p>
+        <div className="space-y-2">
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={modelDraft}
+              onChange={(e) => setModelDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") { e.preventDefault(); addListItem("dataModels", modelDraft, () => setModelDraft("")) }
+              }}
+              placeholder="model-name"
+              className="flex-1 rounded-md border border-border bg-background px-3 py-1.5 text-sm"
+            />
+            <button
+              type="button"
+              onClick={() => addListItem("dataModels", modelDraft, () => setModelDraft(""))}
+              className="rounded-md bg-primary px-3 py-1.5 text-sm text-white hover:bg-primary/90"
+            >Add</button>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {(app.dataModels || []).map((m) => (
+              <span
+                key={m}
+                className="inline-flex items-center gap-1 rounded-full bg-accent px-3 py-1 text-xs"
+              >
+                {m}
+                <button
+                  type="button"
+                  onClick={() => removeListItem("dataModels", m)}
+                  className="text-muted hover:text-red-500"
+                  aria-label={`Remove ${m}`}
+                >✕</button>
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Integrations */}
+      <div>
+        <p className="text-sm font-medium mb-2">Integrations</p>
+        <p className="text-xs text-muted mb-2">Third-party services: e.g. slack, github, stripe, linear.</p>
+        <div className="space-y-2">
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={integrationDraft}
+              onChange={(e) => setIntegrationDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") { e.preventDefault(); addListItem("integrations", integrationDraft, () => setIntegrationDraft("")) }
+              }}
+              placeholder="integration-name"
+              className="flex-1 rounded-md border border-border bg-background px-3 py-1.5 text-sm"
+            />
+            <button
+              type="button"
+              onClick={() => addListItem("integrations", integrationDraft, () => setIntegrationDraft(""))}
+              className="rounded-md bg-primary px-3 py-1.5 text-sm text-white hover:bg-primary/90"
+            >Add</button>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {(app.integrations || []).map((m) => (
+              <span
+                key={m}
+                className="inline-flex items-center gap-1 rounded-full bg-accent px-3 py-1 text-xs"
+              >
+                {m}
+                <button
+                  type="button"
+                  onClick={() => removeListItem("integrations", m)}
+                  className="text-muted hover:text-red-500"
+                  aria-label={`Remove ${m}`}
+                >✕</button>
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Agent Workflow Hints */}
+      <div>
+        <p className="text-sm font-medium mb-2">Agent Workflow</p>
+        <p className="text-xs text-muted mb-3">Optional hints for how agents collaborate on this project.</p>
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            <label className="w-24 text-sm text-muted">Builder</label>
+            <input
+              type="text"
+              value={workflow.builder || ""}
+              onChange={(e) => updateWorkflow("builder", e.target.value)}
+              placeholder="e.g. claude-code builds features"
+              className="flex-1 rounded-md border border-border bg-background px-3 py-1.5 text-sm"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <label className="w-24 text-sm text-muted">Updater</label>
+            <input
+              type="text"
+              value={workflow.updater || ""}
+              onChange={(e) => updateWorkflow("updater", e.target.value)}
+              placeholder="e.g. hermes updates task state"
+              className="flex-1 rounded-md border border-border bg-background px-3 py-1.5 text-sm"
+            />
+          </div>
+          <div className="flex items-start gap-2">
+            <label className="w-24 pt-2 text-sm text-muted">Escalation</label>
+            <textarea
+              value={workflow.escalation || ""}
+              onChange={(e) => updateWorkflow("escalation", e.target.value)}
+              placeholder="Blocker handling / escalation rules"
+              rows={2}
+              className="flex-1 rounded-md border border-border bg-background px-3 py-1.5 text-sm"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/form/step-pages.tsx
+++ b/src/components/form/step-pages.tsx
@@ -47,6 +47,15 @@ export function StepPages({ form, errors }: Props) {
     form.setValue(fieldPath, value, { shouldDirty: true })
   }
 
+  function updateType(index: number, value: string) {
+    const typePath = `content.pages.${index}.type` as const
+    form.setValue(
+      typePath,
+      (value || undefined) as ProjectConfig["content"]["pages"][number]["type"],
+      { shouldDirty: true }
+    )
+  }
+
   function toggleSection(index: number, section: string) {
     const current = pages[index]?.sections || []
     const sections = current.includes(section)
@@ -109,6 +118,24 @@ export function StepPages({ form, errors }: Props) {
                   className="rounded border px-2 py-1 text-xs text-red-500"
                 >✕</button>
               </div>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <label className="text-sm text-muted w-16">Type</label>
+              <select
+                value={page.type || ""}
+                onChange={(e) => updateType(i, e.target.value)}
+                className="rounded-md border border-border bg-background px-3 py-1.5 text-sm"
+              >
+                <option value="">— none —</option>
+                <option value="landing">Landing</option>
+                <option value="dashboard">Dashboard</option>
+                <option value="settings">Settings</option>
+                <option value="list">List</option>
+                <option value="detail">Detail</option>
+                <option value="board">Board</option>
+                <option value="admin">Admin</option>
+              </select>
             </div>
 
             <div>

--- a/src/components/form/step-review.tsx
+++ b/src/components/form/step-review.tsx
@@ -57,6 +57,18 @@ export function StepReview({ data }: Props) {
           <span className="font-medium">{data.content.pages.length} page(s)</span>
         </div>
         <div className="flex justify-between">
+          <span className="text-muted">Capabilities</span>
+          <span className="font-medium">{data.app?.capabilities?.length || 0}</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-muted">Data models</span>
+          <span className="font-medium">{data.app?.dataModels?.length || 0}</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-muted">Integrations</span>
+          <span className="font-medium">{data.app?.integrations?.length || 0}</span>
+        </div>
+        <div className="flex justify-between">
           <span className="text-muted">Framework</span>
           <span className="font-medium capitalize">{data.tech.framework}</span>
         </div>

--- a/src/lib/config/schema.ts
+++ b/src/lib/config/schema.ts
@@ -29,9 +29,17 @@ export const ProjectConfigSchema = z.object({
         slug: z.string().min(1, "Page slug is required"),
         sections: z.array(z.string()),
         description: z.string(),
+        type: z
+          .enum(["landing", "dashboard", "settings", "list", "detail", "board", "admin"])
+          .optional(),
       })
     ).min(1, "At least one page is required"),
     assets: z.array(z.string()),
+  }),
+  app: z.object({
+    capabilities: z.array(z.string()),
+    dataModels: z.array(z.string()),
+    integrations: z.array(z.string()),
   }),
   tech: z.object({
     framework: z.enum(["next", "astro", "vite"]),
@@ -43,6 +51,11 @@ export const ProjectConfigSchema = z.object({
   agents: z.object({
     lead: z.enum(["claude-code", "codex", "hermes"]),
     reviewer: z.enum(["claude-code", "codex", "hermes"]),
+    workflow: z.object({
+      builder: z.string(),
+      updater: z.string(),
+      escalation: z.string(),
+    }),
   }),
 })
 
@@ -77,6 +90,11 @@ export const defaultConfig: ProjectConfig = {
     ],
     assets: [],
   },
+  app: {
+    capabilities: [],
+    dataModels: [],
+    integrations: [],
+  },
   tech: {
     framework: "next",
     deploy: "static",
@@ -87,5 +105,10 @@ export const defaultConfig: ProjectConfig = {
   agents: {
     lead: "claude-code",
     reviewer: "codex",
+    workflow: {
+      builder: "",
+      updater: "",
+      escalation: "",
+    },
   },
 }


### PR DESCRIPTION
## Summary
- **Page types**: optional `page.type` enum (`landing | dashboard | settings | list | detail | board | admin`) + dropdown in StepPages
- **App shape**: new top-level `app` block with `capabilities`, `dataModels`, `integrations` arrays
- **Agent workflow hints**: `agents.workflow.{builder,updater,escalation}` for how agents collaborate
- **New wizard step**: `StepApp` between Pages and Tech — chip multi-select for capabilities (with custom add), add/remove lists for data models and integrations, free-text workflow hints
- **Review summary**: surfaces counts for capabilities / data models / integrations

## Why
Schema was biased toward brochure sites. Kanban boards, dashboards, and admin panels need first-class concepts (page types, capabilities, data models, integrations) rather than being shoehorned into section chips.

## Verification
- `pnpm lint` ✅
- `pnpm build` (static export) ✅
- Manual QA: `/new` wizard now shows 6 steps; App Shape step accepts built-in + custom capabilities, data models, integrations; page type dropdown persists per page; all fields round-trip through YAML/JSON/MD export

Fixes #20