### PR TITLE
docs: require reviewer signatures on PR comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,19 @@ Internal configuration frontend for generating project specifications. Outputs `
 4. PR body must reference an Issue (`Fixes #N`)
 5. Self-review your diff before opening a PR
 6. Run end-session audit before signing off
+7. Every PR comment must end with a reviewer signature (see below)
+
+## Reviewer Signatures
+
+Every PR comment — review summaries, inline comments, approval/rejection notes — must end with a signature line identifying the agent:
+
+```
+— Hermes
+— Claude Code
+— Codex
+```
+
+This keeps accountability, thread context, and cross-review clarity intact when multiple agents touch the same PR.
 
 ## Tech Stack
 - Next.js 15 (App Router, **static export**)

--- a/docs/workflows/index.md
+++ b/docs/workflows/index.md
@@ -37,6 +37,18 @@ Look for: console.log, unused imports, type issues, formatting.
   4. Code style matches conventions?
   5. No debug code left in?
 
+## Reviewer Signatures
+
+Every PR comment must end with a signature line identifying the agent that wrote it:
+
+```
+— Hermes
+— Claude Code
+— Codex
+```
+
+Applies to: review summaries, inline comments, approval/rejection notes. Keeps accountability and thread context when multiple agents touch the same PR.
+
 ## Merge Verification (after API merge call)
 
 1. Parse response: check `"merged": true` in JSON


### PR DESCRIPTION
## Summary
- Add rule 7 to AGENTS.md requiring a reviewer signature line on every PR comment
- Add matching \"Reviewer Signatures\" section to AGENTS.md and [docs/workflows/index.md](docs/workflows/index.md)
- Signature formats: \`— Hermes\`, \`— Claude Code\`, \`— Codex\`
- Applies to review summaries, inline comments, approval/rejection notes

## Why
When multiple agents review the same PR, comments without a signature blur together and accountability is lost. A trailing signature keeps thread context and cross-review clarity intact.

## Note on the third acceptance criterion
> Existing \`multi-agent-dev-workflow\` skill updated to reflect this convention

No \`multi-agent-dev-workflow\` skill exists in this repo — \`.claude/skills/\` only contains \`end-session-audit.md\`. If the skill is meant to live here and hasn't been added yet, this can be revisited in a follow-up once the skill file exists.

## Verification
- \`AGENTS.md\` has new rule 7 + \"Reviewer Signatures\" section with format examples
- \`docs/workflows/index.md\` has matching \"Reviewer Signatures\" section under Cross-Review Rules
- No code changes, no lint/build impact

Fixes #14

— Claude Code